### PR TITLE
Work with Data stores in the CLI (and support Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Options:
 Commands:
   organization
   user-scenario
+  data-store
 ```
 
 ### Listing organizations
@@ -161,6 +162,33 @@ If you need to bypass the verifying you can add the ```--yes``` flag.
 ```
 $ loadimpact user-scenario delete 1 --yes
 
+```
+
+## Working with Data stores
+
+A Data store contains a .csv-file where you define values you want to use in your test. A Data store can be reused in many tests, making test-setups easier. For example a Data store .csv-file can contain [URL:s](http://support.loadimpact.com/knowledgebase/articles/174987-random-url-from-a-data-store) for a test. 
+
+### Downloading a Data store
+
+The ```data-store download``` command will download the .csv-file of the specified Data store. If the ```--file_name```-flag is omitted the file will be saved in the current directory as DATA-STORE-ID.csv
+
+```
+$ loadimpact data-store download 1 --file_name /path/where/you/want/file.csv
+
+```
+
+### Creating a Data store
+The ```data-store create``` command will create a new Data store containing the file specified.
+
+```
+$ loadimpact data-store create /path/to/file.csv 'Your Data store name'
+```
+
+### Updating a Data store
+The ```data-store update``` command will update the file of the specified Data store.
+
+```
+$ loadimpact data-store update 1 /path/to/file.csv
 ```
 
 ## Contribute!

--- a/loadimpactcli/config.py
+++ b/loadimpactcli/config.py
@@ -35,6 +35,10 @@ if platform == "darwin":
 if platform == "linux" or platform == "linux2":
     config_file_path = '{0}/.config/LoadImpact/config.ini'.format(home)
 
+# Windows
+if platform == "win32":
+    config_file_path = '{0}\AppData\LoadImpact\config.ini'.format(home)
+
 
 def build_config():
     new_config = configparser.RawConfigParser()

--- a/loadimpactcli/datastore_commands.py
+++ b/loadimpactcli/datastore_commands.py
@@ -125,7 +125,6 @@ def update_datastore(id, datastore_file, name, project_id, delimiter, separator,
 
 def _wait_for_conversion(data_store):
     while not data_store.has_conversion_finished():
-        data_store = client.get_data_store(data_store.id)
         sleep(3)
     return data_store
 

--- a/loadimpactcli/datastore_commands.py
+++ b/loadimpactcli/datastore_commands.py
@@ -1,0 +1,142 @@
+# coding=utf-8
+"""
+Copyright 2016 Load Impact
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import click
+import requests
+import shutil
+from six import raise_from
+from time import sleep
+
+from loadimpact3.exceptions import ConnectionError
+from loadimpact3 import DataStore
+
+from .client import client
+from .config import DEFAULT_PROJECT
+from .errors import CLIError
+
+
+@click.group(name='data-store')
+@click.pass_context
+def data_store(ctx):
+    pass
+
+
+@data_store.command('list', short_help='List datastore.')
+@click.option('--project_id', default=DEFAULT_PROJECT, envvar='DEFAULT_PROJECT', help='Id of the project to list data stores from.')
+def list_datastore(project_id):
+
+    if project_id is None:
+        raise_from(CLIError('You need to provide a project id.'), None)
+
+    try:
+        data_stores = client.list_data_stores(project_id)
+        for data_store in data_stores:
+            click.echo("{0}\t{1}".format(data_store.id, data_store.name))
+    except ConnectionError:
+        click.echo("Cannot connect to Load impact API")
+
+
+@data_store.command('download', short_help='Get datastore CSV.')
+@click.argument('datastore_id')
+@click.option('--file_name', help='Full path of file to save downloaded datastore in.')
+def download_csv(datastore_id, file_name):
+    try:
+        data_store = client.get_data_store(datastore_id)
+        file_path = file_name if file_name else "{0}.csv".format(data_store.id)
+        click.echo("Downloading CSV file, please wait.")
+        _download_csv(data_store, file_path)
+        click.echo("Finished download.")
+    except ConnectionError:
+        click.echo("Cannot connect to Load impact API")
+
+
+@data_store.command('create', short_help='Create datastore.')
+@click.argument('datastore_file', type=click.File('r'))
+@click.argument('name')
+@click.option('--delimiter', default='double', help='CSV file delimiter.')
+@click.option('--separator', default='comma', help='CSV file separator.')
+@click.option('--fromline', default=1, help='CSV file read from line')
+@click.option('--project_id', default=DEFAULT_PROJECT, envvar='DEFAULT_PROJECT', help='Id of the project to create the data store in.')
+def create_datastore(datastore_file, name, project_id, delimiter, separator, fromline):
+
+    if project_id is None:
+        raise_from(CLIError('You need to provide a project id.'), None)
+    try:
+        file_obj = datastore_file
+        data_store_json = {
+            'name': name,
+            'project_id': project_id,
+            'delimiter': delimiter,
+            'separator': separator,
+            'fromline': fromline,
+        }
+        data_store = client.create_data_store(data_store_json, file_obj)
+        data_store = _wait_for_conversion(data_store)
+
+        click.echo("Data store conversion completed with status '{0}'".format(
+                   (DataStore.status_code_to_text(data_store.status))))
+
+        click.echo(data_store)
+    except ConnectionError:
+        click.echo("Cannot connect to Load impact API")
+
+
+@data_store.command('update', short_help='Update datastore.')
+@click.argument('id')
+@click.argument('datastore_file', type=click.File('r'))
+@click.option('--name', default=None)
+@click.option('--delimiter', default='double', help='CSV file delimiter.')
+@click.option('--separator', default='comma', help='CSV file separator.')
+@click.option('--fromline', default=1, help='CSV file read from line')
+@click.option('--project_id', default=DEFAULT_PROJECT, envvar='DEFAULT_PROJECT', help='Project id of the data store')
+def update_datastore(id, datastore_file, name, project_id, delimiter, separator, fromline):
+    if project_id is None:
+        raise_from(CLIError('You need to provide a project id.'), None)
+    try:
+        data_store = client.get_data_store(id)
+        file_obj = datastore_file
+        data_store_json = {
+            'name': name if name else data_store.name,
+            'project_id': project_id,
+            'delimiter': delimiter,
+            'separator': separator,
+            'fromline': fromline,
+        }
+        data_store = client.update_data_store(id, data_store_json, file_obj)
+        data_store = _wait_for_conversion(data_store)
+
+        click.echo("Data store conversion completed with status '{0}'".format(
+                  (DataStore.status_code_to_text(data_store.status))))
+
+        click.echo(data_store)
+    except ConnectionError:
+        click.echo("Cannot connect to Load impact API")
+
+
+def _wait_for_conversion(data_store):
+    while not data_store.has_conversion_finished():
+        data_store = client.get_data_store(data_store.id)
+        sleep(3)
+    return data_store
+
+
+def _download_csv(user_scenario, file_path):
+    response = requests.get(user_scenario.public_url, stream=True)
+    if response.status_code == 200:
+        with open(file_path, 'wb') as f:
+            response.raw.decode_content = True
+            shutil.copyfileobj(response.raw, f)

--- a/loadimpactcli/datastore_commands.py
+++ b/loadimpactcli/datastore_commands.py
@@ -90,7 +90,6 @@ def create_datastore(datastore_file, name, project_id, delimiter, separator, fro
         click.echo("Data store conversion completed with status '{0}'".format(
                    (DataStore.status_code_to_text(data_store.status))))
 
-        click.echo(data_store)
     except ConnectionError:
         click.echo("Cannot connect to Load impact API")
 
@@ -122,7 +121,6 @@ def update_datastore(id, datastore_file, name, project_id, delimiter, separator,
         click.echo("Data store conversion completed with status '{0}'".format(
                   (DataStore.status_code_to_text(data_store.status))))
 
-        click.echo(data_store)
     except ConnectionError:
         click.echo("Cannot connect to Load impact API")
 

--- a/loadimpactcli/datastore_commands.py
+++ b/loadimpactcli/datastore_commands.py
@@ -18,7 +18,6 @@ limitations under the License.
 import click
 import requests
 import shutil
-from six import raise_from
 from time import sleep
 
 from loadimpact3.exceptions import ConnectionError
@@ -26,7 +25,6 @@ from loadimpact3 import DataStore
 
 from .client import client
 from .config import DEFAULT_PROJECT
-from .errors import CLIError
 
 
 @click.group(name='data-store')
@@ -39,8 +37,8 @@ def data_store(ctx):
 @click.option('--project_id', default=DEFAULT_PROJECT, envvar='DEFAULT_PROJECT', help='Id of the project to list data stores from.')
 def list_datastore(project_id):
 
-    if project_id is None:
-        raise_from(CLIError('You need to provide a project id.'), None)
+    if not project_id:
+        return click.echo('You need to provide a project id.')
 
     try:
         data_stores = client.list_data_stores(project_id)
@@ -73,8 +71,8 @@ def download_csv(datastore_id, file_name):
 @click.option('--project_id', default=DEFAULT_PROJECT, envvar='DEFAULT_PROJECT', help='Id of the project to create the data store in.')
 def create_datastore(datastore_file, name, project_id, delimiter, separator, fromline):
 
-    if project_id is None:
-        raise_from(CLIError('You need to provide a project id.'), None)
+    if not project_id:
+        return click.echo('You need to provide a project id.')
     try:
         file_obj = datastore_file
         data_store_json = {
@@ -103,8 +101,8 @@ def create_datastore(datastore_file, name, project_id, delimiter, separator, fro
 @click.option('--fromline', default=1, help='CSV file read from line')
 @click.option('--project_id', default=DEFAULT_PROJECT, envvar='DEFAULT_PROJECT', help='Project id of the data store')
 def update_datastore(id, datastore_file, name, project_id, delimiter, separator, fromline):
-    if project_id is None:
-        raise_from(CLIError('You need to provide a project id.'), None)
+    if not project_id:
+        return click.echo('You need to provide a project id.')
     try:
         data_store = client.get_data_store(id)
         file_obj = datastore_file

--- a/loadimpactcli/loadimpact_cli.py
+++ b/loadimpactcli/loadimpact_cli.py
@@ -19,6 +19,7 @@ import click
 
 from .userscenario_commands import userscenario
 from .organization_commands import organization
+from .datastore_commands import data_store
 
 
 @click.group()
@@ -30,6 +31,7 @@ def cli(ctx):
 def run_cli():
     cli.add_command(userscenario)
     cli.add_command(organization)
+    cli.add_command(data_store)
     cli()
 
 if __name__ == '__main__':

--- a/loadimpactcli/userscenario_commands.py
+++ b/loadimpactcli/userscenario_commands.py
@@ -18,13 +18,11 @@ limitations under the License.
 from time import sleep
 import click
 from tzlocal import get_localzone
-from six import raise_from
 
 from loadimpact3.exceptions import ConnectionError
 
 from .client import client
 from .config import DEFAULT_PROJECT
-from .errors import CLIError
 
 
 @click.group(name='user-scenario')
@@ -46,8 +44,8 @@ def get_scenario(id):
 @userscenario.command('list', short_help='List user-scenarios.')
 @click.option('--project_id', default=DEFAULT_PROJECT, envvar='DEFAULT_PROJECT', help='Id of the project to list scenarios from.')
 def list_scenarios(project_id):
-    if project_id is None:
-        raise_from(CLIError('You need to provide a project id.'), None)
+    if not project_id:
+        return click.echo('You need to provide a project id.')
     try:
         userscenarios = client.list_user_scenarios(project_id)
         for userscenario in userscenarios:
@@ -62,7 +60,7 @@ def list_scenarios(project_id):
 @click.option('--project_id', default=DEFAULT_PROJECT, envvar='DEFAULT_PROJECT', help='Id of the project the scenario should be in.')
 def create_scenario(script_file, name, project_id):
     if not project_id:
-        raise CLIError('You need to provide a project id.')
+        return click.echo('You need to provide a project id.')
     script = read_file(script_file)
     data = {
         u"name": name,

--- a/loadimpactcli/userscenario_commands.py
+++ b/loadimpactcli/userscenario_commands.py
@@ -51,7 +51,7 @@ def list_scenarios(project_id):
     try:
         userscenarios = client.list_user_scenarios(project_id)
         for userscenario in userscenarios:
-            click.echo(userscenario.script)
+            click.echo('{0}\t{1}'.format(userscenario.id, userscenario.name))
     except ConnectionError:
         click.echo("Cannot connect to Load impact API")
 
@@ -116,7 +116,7 @@ def delete_user_scenario(scenario_id):
 
 def update_user_scenario_script(scenario_id, script):
     userscenario = client.get_user_scenario(scenario_id)
-    userscenario.update({'script': script})
+    userscenario.update_scenario({'script': script})
     return client.get_user_scenario(scenario_id)
 
 

--- a/loadimpactcli/version.py
+++ b/loadimpactcli/version.py
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = '1.0.4'
+__version__ = '1.0.5'

--- a/tests/test_datastore_commands.py
+++ b/tests/test_datastore_commands.py
@@ -59,6 +59,13 @@ class TestDataStores(unittest.TestCase):
         assert result.exit_code == 0
         assert result.output == "1\tFirst datastore\n2\tSecond datastore\n"
 
+    def test_list_datastore_missing_project_id(self):
+        client = datastore_commands.client
+        client.list_data_stores = MagicMock(return_value=[self.datastore1, self.datastore2])
+        result = self.runner.invoke(datastore_commands.list_datastore, [])
+        assert result.exit_code == 0
+        assert result.output == "You need to provide a project id.\n"
+
     def test_create_datastore(self):
         client = datastore_commands.client
         client.DEFAULT_PROJECT = 1
@@ -71,6 +78,15 @@ class TestDataStores(unittest.TestCase):
                                                                           '1'])
         assert result.exit_code == 0
         assert result.output == "{0}\n".format("Data store conversion completed with status 'unknown'")
+
+    def test_create_datastore_missing_params(self):
+        client = datastore_commands.client
+        client.DEFAULT_PROJECT = 1
+
+        client.create_data_store = MagicMock(return_value=self.datastore1)
+        datastore_commands._wait_for_conversion = MagicMock(return_value=self.datastore1)
+        result = self.runner.invoke(datastore_commands.create_datastore, ['tests/script'])
+        assert result.exit_code == 2
 
     def test_update_datastore(self):
         client = datastore_commands.client
@@ -88,3 +104,14 @@ class TestDataStores(unittest.TestCase):
                                                                           '1'])
         assert result.exit_code == 0
         assert result.output == "{0}\n".format("Data store conversion completed with status 'unknown'")
+
+    def test_update_datastore_missing_params(self):
+        client = datastore_commands.client
+        client.DEFAULT_PROJECT = 1
+
+        client.get_data_store = MagicMock(return_value=self.datastore2)
+        client.update_data_store = MagicMock(return_value=self.datastore2)
+        datastore_commands._wait_for_conversion = MagicMock(return_value=self.datastore2)
+
+        result = self.runner.invoke(datastore_commands.update_datastore, ['1'])
+        assert result.exit_code == 2

--- a/tests/test_datastore_commands.py
+++ b/tests/test_datastore_commands.py
@@ -43,7 +43,6 @@ class TestDataStores(unittest.TestCase):
         datastore_commands._download_csv = MagicMock()
         client.get_data_store = MagicMock(return_value=self.datastore1)
         result = self.runner.invoke(datastore_commands.download_csv, ['1'])
-        print(result)
         assert result.exit_code == 0
         assert result.output == "Downloading CSV file, please wait.\nFinished download.\n"
 
@@ -71,7 +70,7 @@ class TestDataStores(unittest.TestCase):
                                                                           '--project_id',
                                                                           '1'])
         assert result.exit_code == 0
-        assert result.output == "{0}\n{1}\n".format("Data store conversion completed with status 'unknown'", self.datastore1)
+        assert result.output == "{0}\n".format("Data store conversion completed with status 'unknown'")
 
     def test_update_datastore(self):
         client = datastore_commands.client
@@ -88,4 +87,4 @@ class TestDataStores(unittest.TestCase):
                                                                           '--project_id',
                                                                           '1'])
         assert result.exit_code == 0
-        assert result.output == "{0}\n{1}\n".format("Data store conversion completed with status 'unknown'", self.datastore2)
+        assert result.output == "{0}\n".format("Data store conversion completed with status 'unknown'")

--- a/tests/test_datastore_commands.py
+++ b/tests/test_datastore_commands.py
@@ -1,0 +1,91 @@
+"""
+Copyright 2016 Load Impact
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+# Without this the config will prompt for a token
+import os
+os.environ['LOADIMPACT_API_TOKEN'] = 'token'
+
+import unittest
+from collections import namedtuple
+
+from click.testing import CliRunner
+from loadimpactcli import datastore_commands
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
+
+class TestDataStores(unittest.TestCase):
+
+    def setUp(self):
+        self.runner = CliRunner()
+        DataStore = namedtuple('DataStore', ['id', 'name', 'status', 'public_url'])
+        self.datastore1 = DataStore(1, 'First datastore', 'status1', 'www.example.com')
+        self.datastore2 = DataStore(2, 'Second datastore', 'status2', 'www.example.com')
+
+    def test_download_csv(self):
+        client = datastore_commands.client
+        datastore_commands._download_csv = MagicMock()
+        client.get_data_store = MagicMock(return_value=self.datastore1)
+        result = self.runner.invoke(datastore_commands.download_csv, ['1'])
+        print(result)
+        assert result.exit_code == 0
+        assert result.output == "Downloading CSV file, please wait.\nFinished download.\n"
+
+    def test_download_csv_no_params(self):
+        result = self.runner.invoke(datastore_commands.download_csv, [])
+        assert result.exit_code == 2
+
+    def test_list_datastore(self):
+        client = datastore_commands.client
+        client.DEFAULT_PROJECT = 1
+        client.list_data_stores = MagicMock(return_value=[self.datastore1, self.datastore2])
+        result = self.runner.invoke(datastore_commands.list_datastore, ['--project_id', '1'])
+
+        assert result.exit_code == 0
+        assert result.output == "1\tFirst datastore\n2\tSecond datastore\n"
+
+    def test_create_datastore(self):
+        client = datastore_commands.client
+        client.DEFAULT_PROJECT = 1
+
+        client.create_data_store = MagicMock(return_value=self.datastore1)
+        datastore_commands._wait_for_conversion = MagicMock(return_value=self.datastore1)
+        result = self.runner.invoke(datastore_commands.create_datastore, ['tests/script',
+                                                                          'NewDatastore',
+                                                                          '--project_id',
+                                                                          '1'])
+        assert result.exit_code == 0
+        assert result.output == "{0}\n{1}\n".format("Data store conversion completed with status 'unknown'", self.datastore1)
+
+    def test_update_datastore(self):
+        client = datastore_commands.client
+        client.DEFAULT_PROJECT = 1
+
+        client.get_data_store = MagicMock(return_value=self.datastore2)
+        client.update_data_store = MagicMock(return_value=self.datastore2)
+        datastore_commands._wait_for_conversion = MagicMock(return_value=self.datastore2)
+
+        result = self.runner.invoke(datastore_commands.update_datastore, ['1',
+                                                                          'tests/script',
+                                                                          '--name',
+                                                                          'New name',
+                                                                          '--project_id',
+                                                                          '1'])
+        assert result.exit_code == 0
+        assert result.output == "{0}\n{1}\n".format("Data store conversion completed with status 'unknown'", self.datastore2)

--- a/tests/test_userscenario_commands.py
+++ b/tests/test_userscenario_commands.py
@@ -47,9 +47,9 @@ class TestUserScenarios(unittest.TestCase):
 
     def setUp(self):
         self.runner = CliRunner()
-        Scenario = namedtuple('Scenario', ['script'])
-        self.scenario1 = Scenario('debug')
-        self.scenario2 = Scenario('info')
+        Scenario = namedtuple('Scenario', ['id', 'name', 'script'])
+        self.scenario1 = Scenario(1, 'Scen1', 'debug')
+        self.scenario2 = Scenario(2, 'Scen2', 'info')
 
     def test_get_scenario(self):
         client = userscenario_commands.client
@@ -70,7 +70,7 @@ class TestUserScenarios(unittest.TestCase):
         result = self.runner.invoke(userscenario_commands.list_scenarios, ['--project_id', '1'])
 
         assert result.exit_code == 0
-        assert result.output == "debug\ninfo\n"
+        assert result.output == "1\tScen1\n2\tScen2\n"
 
     def test_create_scenario(self):
         client = userscenario_commands.client


### PR DESCRIPTION
Added functionality for downloading and updating Data Stores from the CLI.
Support running the CLI on Windows (basically means creating/finding the config file, no major changes.)

Also made some general fixes such as not raising an error when a required project_id is missing. 