### PR TITLE
Support for test listing, running and metrics via v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,12 @@ $ loadimpact test list --project_id 100 --project_id 200 --limit 5
 
 Will display the five most recent Tests from projects 100 and 200.
 
+The command truncates the values of several columns (*Name* and *Config*) for
+the purposes of readability. This can be overriden by the `--full-width`
+argument, which will cause the information to be displayed fully and separated
+by tab characters (`\t`).
+
+
 #### Running Tests
 
 The `test run` command launches a Test Run from an existing Test:

--- a/README.md
+++ b/README.md
@@ -80,14 +80,18 @@ $ loadimpact
 Usage: loadimpact [OPTIONS] COMMAND [ARGS]...
 
 Options:
-  --help  Show this message and exit.
   --version  Show the version and exit.
+  --help     Show this message and exit.
 
 Commands:
-  organization
-  user-scenario
   data-store
+  metric
+  organization
+  test
+  user-scenario
 ```
+
+## Working with organizations and projects
 
 #### Listing organizations
 
@@ -233,6 +237,83 @@ The ```data-store update``` command will update the file of the specified Data s
 
 ```
 $ loadimpact data-store update 1 /path/to/file.csv
+```
+
+## Working with Tests
+
+#### Listing Tests
+
+The `test list` command lists the Tests you have access to:
+```
+$ loadimpact test list
+
+ID: NAME:           LAST RUN DATE:        LAST RUN STATUS:    CONFIG:
+123 My test name    2017-01-02 03:04:05   Finished            #321 100% at amazon:ie:dublin | 1s 50users
+456 My second test  2017-02-03 12:34:56   Aborted by user     #987 100% at amazon:ie:dublin | 10s 50users
+```
+
+By default, it will display all the Tests from all the Projects from all the
+Organizations you have access to. This can be narrowed down by the
+`--project_id` flag:
+```
+$ loadimpact test list --project_id 100 --project_id 200
+```
+
+#### Running Tests
+
+The `test run` command launches a Test Run from an existing Test:
+```
+$ loadimpact test run 123
+```
+
+The command will periodically print the metrics collected during the test run
+(defaulting to VUs, requests/second, bandwidth, VU load time and failure rate)
+until the test run is finished:
+
+```
+$ loadimpact test run 123
+
+TEST_RUN_ID:
+456
+TIMESTAMP:           METRIC:                      AGGREGATE:  VALUE:
+2017-01-02 03:04:00  __li_bandwidth:1             avg         1111.2222
+2017-01-02 03:04:00  __li_clients_active:1        value       5.0
+2017-01-02 03:04:00  __li_requests_per_second:1   avg         8.7654321
+2017-01-02 03:04:03  __li_bandwidth:1             avg         2222.3333
+2017-01-02 03:04:03  __li_clients_active:1        value       10.0
+2017-01-02 03:04:03  __li_requests_per_second:1   avg         9.8765432
+...
+```
+
+This output can be disabled by the `--quiet` flag. The metrics displayed can
+also be selected using the `--metric` flag:
+
+```
+$ loadimpact test run 123 --metric __li_bandwidth --metric __li_clients_active:1
+```
+
+## Working with Metrics
+
+#### Listing Metrics
+
+The `metric list` command lists the Metrics available for a Test Run:
+```
+$ loadimpact metric list 789
+
+NAME:                                                       TYPE:
+__li_user_load_time:1                                       common
+__li_total_requests:1                                       common
+...
+__li_url_b2d8b7afb66fd4d3c7faf263b13228e9:13:225:200:GET    url
+__li_url_b2d8b7afb66fd4d3c7faf263b13228e9:1:225:200:GET url
+...
+```
+
+The list of metrics to output can be narrowed down by metric type by using the
+`--type` flag:
+
+```
+$ loadimpact metric list 789 --type common --type log
 ```
 
 ## Contribute!

--- a/README.md
+++ b/README.md
@@ -252,12 +252,15 @@ ID: NAME:           LAST RUN DATE:        LAST RUN STATUS:    CONFIG:
 456 My second test  2017-02-03 12:34:56   Aborted by user     10 users 5s; 100 users 60s
 ```
 
-By default, it will display all the Tests from all the Projects from all the
-Organizations you have access to. This can be narrowed down by the
-`--project_id` flag:
+By default, it will display the first 20 Tests, ordered by their last run
+date, from all the Projects from all the Organizations you have access to.
+This can be narrowed down by the `--project_id` and the `--limit` flags. For
+example, the following command:
 ```
-$ loadimpact test list --project_id 100 --project_id 200
+$ loadimpact test list --project_id 100 --project_id 200 --limit 5
 ```
+
+Will display the five most recent Tests from projects 100 and 200.
 
 #### Running Tests
 
@@ -275,6 +278,8 @@ $ loadimpact test run 123
 
 TEST_RUN_ID:
 456
+
+'Initializing test ...'
 TIMESTAMP:           VUs [1]: reqs/s [1]: bandwidth [1]: user load time [1]: failure rate [1]:
 2017-01-02 03:04:00  5.0      6.626671    89340.2656     -                   -
 2017-01-02 03:04:03  8.0      3.956092    53336.0410     -                   -
@@ -293,7 +298,7 @@ the `--raw_metric` flag (that allows the passing of parameters for the metrics
 as defined the [in the documentation][api-results] directly):
 
 ```
-$ loadimpact test run 123 --metric bandwidth --raw_metric __li_url_c7cb000532b49c3b1c3f3c1928f74b88:1:225:200:GET
+$ loadimpact test run 123 --metric bandwidth --raw_metric __li_url_XYZ:1:225:200:GET
 ```
 
 Please note that the default metrics (the ones selected by using the

--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ The `test list` command lists the Tests you have access to:
 $ loadimpact test list
 
 ID: NAME:           LAST RUN DATE:        LAST RUN STATUS:    CONFIG:
-123 My test name    2017-01-02 03:04:05   Finished            #321 100% at amazon:ie:dublin | 1s 50users
-456 My second test  2017-02-03 12:34:56   Aborted by user     #987 100% at amazon:ie:dublin | 10s 50users
+123 My test name    2017-01-02 03:04:05   Finished            50 users 2s
+456 My second test  2017-02-03 12:34:56   Aborted by user     10 users 5s; 100 users 60s
 ```
 
 By default, it will display all the Tests from all the Projects from all the

--- a/README.md
+++ b/README.md
@@ -275,22 +275,30 @@ $ loadimpact test run 123
 
 TEST_RUN_ID:
 456
-TIMESTAMP:           METRIC:                      AGGREGATE:  VALUE:
-2017-01-02 03:04:00  __li_bandwidth:1             avg         1111.2222
-2017-01-02 03:04:00  __li_clients_active:1        value       5.0
-2017-01-02 03:04:00  __li_requests_per_second:1   avg         8.7654321
-2017-01-02 03:04:03  __li_bandwidth:1             avg         2222.3333
-2017-01-02 03:04:03  __li_clients_active:1        value       10.0
-2017-01-02 03:04:03  __li_requests_per_second:1   avg         9.8765432
+TIMESTAMP:           VUs [1]: reqs/s [1]: bandwidth [1]: user load time [1]: failure rate [1]:
+2017-01-02 03:04:00  5.0      6.626671    89340.2656     -                   -
+2017-01-02 03:04:03  8.0      3.956092    53336.0410     -                   -
+2017-01-02 03:04:06  10.0     2.644981    35659.6385     -                   -
+2017-01-02 03:04:09  15.0     3.970042    53524.1070     -                   -
+2017-01-02 03:04:12  17.0     2.646911    35685.6541     -                   -
+2017-01-02 03:04:15  20.0     3.969141    53511.9623     -                   -
+2017-01-02 03:04:18  22.0     6.613472    89162.8336     235.73              -
+2017-01-02 03:04:21  25.0     5.289569    71313.9719     234.3               -
 ...
 ```
 
 This output can be disabled by the `--quiet` flag. The metrics displayed can
-also be selected using the `--metric` flag:
+also be selected using the `--metric` flag (in the case of default metrics) or
+the `--raw_metric` flag (that allows the passing of parameters for the metrics
+as defined the [in the documentation][api-results] directly):
 
 ```
-$ loadimpact test run 123 --metric __li_bandwidth --metric __li_clients_active:1
+$ loadimpact test run 123 --metric bandwidth --raw_metric __li_url_c7cb000532b49c3b1c3f3c1928f74b88:1:225:200:GET
 ```
+
+Please note that the default metrics (the ones selected by using the
+`--metric` flag) will by default display the first aggregation function for
+the aggregated world load zone.
 
 ## Working with Metrics
 
@@ -300,12 +308,15 @@ The `metric list` command lists the Metrics available for a Test Run:
 ```
 $ loadimpact metric list 789
 
-NAME:                                                       TYPE:
-__li_user_load_time:1                                       common
-__li_total_requests:1                                       common
-...
-__li_url_b2d8b7afb66fd4d3c7faf263b13228e9:13:225:200:GET    url
-__li_url_b2d8b7afb66fd4d3c7faf263b13228e9:1:225:200:GET url
+NAME:                                                    ARGUMENT NAME:  TYPE:
+__li_bandwidth:1                                         bandwidth       common
+__li_bandwidth:13                                        bandwidth       common
+__li_clients_active:1                                    clients_active  common
+__li_clients_active:13                                   clients_active  common
+__li_user_load_time:1                                    user_load_time  common
+__li_user_load_time:13                                   user_load_time  common
+__li_url_69e369c64ef5e40f6fd8566e4163860d:13:225:200:GET -               url
+__li_url_69e369c64ef5e40f6fd8566e4163860d:1:225:200:GET  -               url
 ...
 ```
 
@@ -326,3 +337,5 @@ $ python setup.py test
 ```
 
 If you've found a bug or something isn't working properly, please don't hesitate to create a ticket for us! 
+
+[api-results]: http://developers.loadimpact.com/api/#get-tests-id-results

--- a/README.md
+++ b/README.md
@@ -262,11 +262,10 @@ $ loadimpact test list --project_id 100 --project_id 200 --limit 5
 
 Will display the five most recent Tests from projects 100 and 200.
 
-The command truncates the values of several columns (*Name* and *Config*) for
+The output truncates the values of several columns (*Name* and *Config*) for
 the purposes of readability. This can be overriden by the `--full-width`
 argument, which will cause the information to be displayed fully and separated
 by tab characters (`\t`).
-
 
 #### Running Tests
 
@@ -310,6 +309,11 @@ $ loadimpact test run 123 --metric bandwidth --raw_metric __li_url_XYZ:1:225:200
 Please note that the default metrics (the ones selected by using the
 `--metric` flag) will by default display the first aggregation function for
 the aggregated world load zone.
+
+The output displays the values using fixed width, truncating if needed, for
+the purposes of readability. This can be overriden by the `--full-width`
+argument, which will cause the information to be displayed fully and separated
+by tab characters (`\t`).
 
 ## Working with Metrics
 

--- a/loadimpactcli/loadimpact_cli.py
+++ b/loadimpactcli/loadimpact_cli.py
@@ -20,6 +20,7 @@ import click
 from .userscenario_commands import userscenario
 from .organization_commands import organization
 from .datastore_commands import data_store
+from .test_commands import test
 from .version import __version__
 
 
@@ -34,6 +35,7 @@ def run_cli():
     cli.add_command(userscenario)
     cli.add_command(organization)
     cli.add_command(data_store)
+    cli.add_command(test)
     cli()
 
 if __name__ == '__main__':

--- a/loadimpactcli/loadimpact_cli.py
+++ b/loadimpactcli/loadimpact_cli.py
@@ -21,6 +21,7 @@ from .userscenario_commands import userscenario
 from .organization_commands import organization
 from .datastore_commands import data_store
 from .test_commands import test
+from .metric_commands import metric
 from .version import __version__
 
 
@@ -36,6 +37,7 @@ def run_cli():
     cli.add_command(organization)
     cli.add_command(data_store)
     cli.add_command(test)
+    cli.add_command(metric)
     cli()
 
 if __name__ == '__main__':

--- a/loadimpactcli/metric_commands.py
+++ b/loadimpactcli/metric_commands.py
@@ -54,6 +54,6 @@ def list_metrics(test_run_id, metric_types):
         click.echo('NAME:\tTYPE:')
         for result_id in sorted(result_ids, key=attrgetter('type')):
             for key, _ in sorted(result_id.ids.items()):
-                click.echo('{0}\t{1}'.format(key, result_id.results_type_code_to_text(result_id.type)))
+                click.echo(u'{0}\t{1}'.format(key, result_id.results_type_code_to_text(result_id.type)))
     except ConnectionError:
         click.echo("Cannot connect to Load impact API")

--- a/loadimpactcli/metric_commands.py
+++ b/loadimpactcli/metric_commands.py
@@ -1,0 +1,60 @@
+# coding=utf-8
+"""
+Copyright 2016 Load Impact
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import click
+
+from loadimpact3.exceptions import ConnectionError
+from .client import client
+
+# TestRunResults type codes.
+TEXT_TO_TYPE_CODE_MAP = {
+    'common': 1,
+    'url': 2,
+    'live_feedback': 3,
+    'log': 4,
+    'custom_metric': 5,
+    'page': 6,
+    'dtp': 7,
+    'system': 8,
+    'server metric': 9,
+    'integration': 10
+}
+
+
+@click.group()
+@click.pass_context
+def metric(ctx):
+    pass
+
+
+@metric.command('list', short_help='List metrics for a test run.')
+@click.argument('test_run_id')
+@click.option('--type', '-t', 'metric_types', multiple=True, type=click.Choice(TEXT_TO_TYPE_CODE_MAP.keys()),
+              help='Metric type to include on the list.')
+def list_metrics(test_run_id, metric_types):
+    try:
+        data = ','.join(str(TEXT_TO_TYPE_CODE_MAP[k]) for k in metric_types)
+        print data
+        test_run = client.get_test_run(test_run_id)
+        result_ids = test_run.list_test_run_result_ids(data=data)
+
+        click.echo('NAME:\tTYPE:')
+        for result_id in result_ids:
+            for key, _ in result_id.ids.iteritems():
+                click.echo('{0}\t{1}'.format(key, result_id.results_type_code_to_text(result_id.type)))
+    except ConnectionError:
+        click.echo("Cannot connect to Load impact API")

--- a/loadimpactcli/metric_commands.py
+++ b/loadimpactcli/metric_commands.py
@@ -48,8 +48,7 @@ def metric(ctx):
 def list_metrics(test_run_id, metric_types):
     try:
         types = ','.join(str(TEXT_TO_TYPE_CODE_MAP[k]) for k in metric_types)
-        test_run = client.get_test_run(test_run_id)
-        result_ids = test_run.list_test_run_result_ids(data={'types': types})
+        result_ids = client.list_test_run_result_ids(test_run_id, data={'types': types})
 
         click.echo('NAME:\tTYPE:')
         for result_id in result_ids:

--- a/loadimpactcli/metric_commands.py
+++ b/loadimpactcli/metric_commands.py
@@ -20,6 +20,7 @@ import click
 
 from loadimpact3.exceptions import ConnectionError
 from .client import client
+from .util import Metric
 
 # TestRunResults type codes.
 TEXT_TO_TYPE_CODE_MAP = {
@@ -51,9 +52,13 @@ def list_metrics(test_run_id, metric_types):
         types = ','.join(str(TEXT_TO_TYPE_CODE_MAP[k]) for k in metric_types)
         result_ids = client.list_test_run_result_ids(test_run_id, data={'types': types})
 
-        click.echo('NAME:\tTYPE:')
+        click.echo('NAME:\tARGUMENT NAME:\tTYPE:')
         for result_id in sorted(result_ids, key=attrgetter('type')):
             for key, _ in sorted(result_id.ids.items()):
-                click.echo(u'{0}\t{1}'.format(key, result_id.results_type_code_to_text(result_id.type)))
+                metric_ = Metric.from_raw(key)
+
+                click.echo(u'{0}\t{1}\t{2}'.format(key,
+                                                   metric_.str_param(),
+                                                   result_id.results_type_code_to_text(result_id.type)))
     except ConnectionError:
         click.echo("Cannot connect to Load impact API")

--- a/loadimpactcli/metric_commands.py
+++ b/loadimpactcli/metric_commands.py
@@ -14,6 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from operator import attrgetter
 
 import click
 
@@ -51,8 +52,8 @@ def list_metrics(test_run_id, metric_types):
         result_ids = client.list_test_run_result_ids(test_run_id, data={'types': types})
 
         click.echo('NAME:\tTYPE:')
-        for result_id in result_ids:
-            for key, _ in result_id.ids.iteritems():
+        for result_id in sorted(result_ids, key=attrgetter('type')):
+            for key, _ in sorted(result_id.ids.items()):
                 click.echo('{0}\t{1}'.format(key, result_id.results_type_code_to_text(result_id.type)))
     except ConnectionError:
         click.echo("Cannot connect to Load impact API")

--- a/loadimpactcli/metric_commands.py
+++ b/loadimpactcli/metric_commands.py
@@ -47,10 +47,9 @@ def metric(ctx):
               help='Metric type to include on the list.')
 def list_metrics(test_run_id, metric_types):
     try:
-        data = ','.join(str(TEXT_TO_TYPE_CODE_MAP[k]) for k in metric_types)
-        print data
+        types = ','.join(str(TEXT_TO_TYPE_CODE_MAP[k]) for k in metric_types)
         test_run = client.get_test_run(test_run_id)
-        result_ids = test_run.list_test_run_result_ids(data=data)
+        result_ids = test_run.list_test_run_result_ids(data={'types': types})
 
         click.echo('NAME:\tTYPE:')
         for result_id in result_ids:

--- a/loadimpactcli/metric_commands.py
+++ b/loadimpactcli/metric_commands.py
@@ -30,7 +30,7 @@ TEXT_TO_TYPE_CODE_MAP = {
     'page': 6,
     'dtp': 7,
     'system': 8,
-    'server metric': 9,
+    'server_metric': 9,
     'integration': 10
 }
 

--- a/loadimpactcli/test_commands.py
+++ b/loadimpactcli/test_commands.py
@@ -95,9 +95,11 @@ def run_test(test_id, quiet, standard_metrics, raw_metrics):
                            Metric(DefaultMetricType.FAILURE_RATE, ['1'])]
 
             stream = test_run.result_stream([m.str_raw(True) for m in metrics])
+            click.echo('Initializing test ...')
 
-            click.echo(pprint_header(metrics))
-            for data in stream(poll_rate=3):
+            for i, data in enumerate(stream(poll_rate=3)):
+                if i % 20 == 0:
+                    click.echo(pprint_header(metrics))
                 click.echo(pprint_row(data, metrics))
 
     except ConnectionError:

--- a/loadimpactcli/test_commands.py
+++ b/loadimpactcli/test_commands.py
@@ -108,12 +108,12 @@ def pprint_row(data, returned_metrics):
     Return a pretty printed string with a row of the metric streaming
     output, consisting of the values of the metrics.
     """
-    parts = ['u{0}'.format(next(iter(data.items()))[1].timestamp)]
+    parts = [u'{0}'.format(next(iter(data.items()))[1].timestamp)]
     for m in returned_metrics:
         try:
             parts.append(unicode(data[m.str_raw(True)].value))
         except KeyError:
-            parts.append('-')
+            parts.append(u'-')
 
     return u'\t'.join(parts)
 

--- a/loadimpactcli/test_commands.py
+++ b/loadimpactcli/test_commands.py
@@ -60,7 +60,7 @@ def list_tests(project_ids):
 @click.argument('test_id')
 @click.option('--quiet/--no-quiet', default=False, help='Disable streaming of metrics to stdout.')
 @click.option('--metric', 'result_ids', multiple=True, help='Name of the metric to stream.')
-def list_tests(test_id, quiet, result_ids):
+def run_tests(test_id, quiet, result_ids):
     try:
         test_ = client.get_test(test_id)
         test_run = test_.start_test_run()

--- a/loadimpactcli/test_commands.py
+++ b/loadimpactcli/test_commands.py
@@ -52,7 +52,7 @@ def list_tests(project_ids):
                 last_run_date = last_run.queued
                 last_run_status = last_run.status_text
 
-            click.echo('{0}\t{1}\t{2}\t{3}\t{4}'.format(
+            click.echo(u'{0}\t{1}\t{2}\t{3}\t{4}'.format(
                 test_.id, test_.name, last_run_date, last_run_status,
                 summarize_config(test_.config)))
     except ConnectionError:
@@ -74,7 +74,7 @@ def run_tests(test_id, quiet, result_ids):
             stream = test_run.result_stream(result_ids)
             for data in stream(poll_rate=3):
                 for metric_id in (result_ids or sorted(data.keys())):
-                    click.echo('{0}\t{1}\t{2}\t{3}'.format(
+                    click.echo(u'{0}\t{1}\t{2}\t{3}'.format(
                         data[metric_id].timestamp,
                         metric_id,
                         data[metric_id].aggregate_function,
@@ -85,14 +85,14 @@ def run_tests(test_id, quiet, result_ids):
 
 def summarize_config(config):
     try:
-        str_tracks = ['#{0} {1}% at {2}'.format(track[u'clips'][0]['user_scenario_id'],
+        str_tracks = [u'#{0} {1}% at {2}'.format(track[u'clips'][0]['user_scenario_id'],
                                                 track[u'clips'][0]['percent'],
                                                 track[u'loadzone'])
                       for track in config[u'tracks']]
-        str_schedules = ['{0}s {1}users'.format(schedule[u'duration'], schedule[u'users'])
+        str_schedules = [u'{0}s {1}users'.format(schedule[u'duration'], schedule[u'users'])
                          for schedule in config[u'load_schedule']]
 
-        return ' | '.join(['; '.join(str_) for str_ in [str_tracks, str_schedules]])
+        return u' | '.join(['; '.join(str_) for str_ in [str_tracks, str_schedules]])
 
     except (KeyError, IndexError, ValueError, TypeError):
         return config

--- a/loadimpactcli/test_commands.py
+++ b/loadimpactcli/test_commands.py
@@ -65,10 +65,14 @@ def list_tests(test_id, quiet, result_ids):
         click.echo('TEST_RUN_ID:\n{0}'.format(test_run.id))
 
         if not quiet:
-            click.echo('METRIC:\tVALUE:')
+            click.echo('TIMESTAMP:\tMETRIC:\tAGGREGATE:\tVALUE:')
             stream = test_run.result_stream(result_ids)
             for data in stream(poll_rate=3):
-                for metric_id in (result_ids or data.keys()):
-                    click.echo('{0}\t{1}'.format(metric_id, data[metric_id]))
+                for metric_id in (result_ids or sorted(data.keys())):
+                    click.echo('{0}\t{1}\t{2}\t{3}'.format(
+                        data[metric_id].timestamp,
+                        metric_id,
+                        data[metric_id].aggregate_function,
+                        data[metric_id].value))
     except ConnectionError:
         click.echo("Cannot connect to Load impact API")

--- a/loadimpactcli/test_commands.py
+++ b/loadimpactcli/test_commands.py
@@ -136,11 +136,11 @@ def get_run_test_formatter(full_width, metrics):
     the `test list` command.
     """
     if full_width:
-        return ColumnFormatter([0] * (len(metrics)+1), '\t')
+        return ColumnFormatter([0] * (len(metrics) + 1), '\t')
     else:
         # Setup the formatter using sensible column widths for each field.
         column_widths = (25,  # timestamp (YYYY-MM-DD HH:mm:ss+ZZ:zz)
-                         ) + tuple(max(16, len(m.str_ui(True))+1) for m in metrics)
+                         ) + tuple(max(16, len(m.str_ui(True)) + 1) for m in metrics)
 
         return ColumnFormatter(column_widths, ' ')
 

--- a/loadimpactcli/test_commands.py
+++ b/loadimpactcli/test_commands.py
@@ -44,14 +44,17 @@ def list_tests(project_ids):
         for id_ in set(project_ids):
             tests.extend(client.list_tests(project_id=id_))
 
-        click.echo("ID:\tNAME:\tLAST RUN DATE:\tCONFIG:")
+        click.echo("ID:\tNAME:\tLAST RUN DATE:\tLAST RUN STATUS:\tCONFIG:")
         for test_ in sorted(tests, key=attrgetter('id')):
-            last_run_date = None
+            last_run_date = last_run_status = '-'
             if test_.last_test_run_id:
-                last_run_date = client.get_test_run(test_.last_test_run_id).queued
+                last_run = client.get_test_run(test_.last_test_run_id)
+                last_run_date = last_run.queued
+                last_run_status = last_run.status_text
 
-            click.echo('{0}\t{1}\t{2}\t{3}'.format(test_.id, test_.name, last_run_date,
-                                                   summarize_config(test_.config)))
+            click.echo('{0}\t{1}\t{2}\t{3}\t{4}'.format(
+                test_.id, test_.name, last_run_date, last_run_status,
+                summarize_config(test_.config)))
     except ConnectionError:
         click.echo("Cannot connect to Load impact API")
 

--- a/loadimpactcli/test_commands.py
+++ b/loadimpactcli/test_commands.py
@@ -65,10 +65,10 @@ def list_tests(project_ids):
 @click.argument('test_id')
 @click.option('--quiet/--no-quiet', default=False, help='Disable streaming of metrics to stdout.')
 @click.option('--metric', 'standard_metrics', multiple=True,
-              help='Name of the standard metric to stream (aggregated world load zone).',
+              help='Name of the standard metric to stream (implies aggregated world load zone).',
               type=click.Choice([m.name.lower() for m in list(DefaultMetricType)]))
 @click.option('--raw_metric', 'raw_metrics', multiple=True, help='Raw name of the metric to stream.')
-def run_tests(test_id, quiet, standard_metrics, raw_metrics):
+def run_test(test_id, quiet, standard_metrics, raw_metrics):
     try:
         test_ = client.get_test(test_id)
         test_run = test_.start_test_run()
@@ -108,10 +108,14 @@ def pprint_row(data, returned_metrics):
     Return a pretty printed string with a row of the metric streaming
     output, consisting of the values of the metrics.
     """
-    parts = [u'{0}'.format(next(iter(data.items()))[1].timestamp)]
+    try:
+        parts = [u'{0}'.format(next(iter(data.items()))[1].timestamp)]
+    except (StopIteration, AttributeError):
+        return u''
+
     for m in returned_metrics:
         try:
-            parts.append(unicode(data[m.str_raw(True)].value))
+            parts.append(u'{0}'.format(data[m.str_raw(True)].value))
         except KeyError:
             parts.append(u'-')
 

--- a/loadimpactcli/test_commands.py
+++ b/loadimpactcli/test_commands.py
@@ -1,0 +1,54 @@
+# coding=utf-8
+"""
+Copyright 2016 Load Impact
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import click
+
+from loadimpact3.exceptions import ConnectionError
+from .client import client
+
+
+@click.group()
+@click.pass_context
+def test(ctx):
+    pass
+
+
+@test.command('list', short_help='List tests.')
+@click.option('--project_id', 'project_ids', multiple=True, help='Id of the project to list tests from.')
+def list_tests(project_ids):
+    try:
+        if not project_ids:
+            # If no project_id is specified, retrieve all projects the user has access to.
+            orgs = client.list_organizations()
+            projs = []
+            for org in orgs:
+                projs.extend(client.list_organization_projects(org_id=org.id))
+            project_ids = [proj.id for proj in projs]
+
+        tests = []
+        for id_ in set(project_ids):
+            tests.extend(client.list_tests(project_id=id_))
+
+        click.echo("ID:\tNAME:\tLAST RUN DATE:\tCONFIG:")
+        for test_ in tests:
+            last_run_date = None
+            if test_.last_test_run_id:
+                last_run_date = client.get_test_run(test_.last_test_run_id).queued
+
+            click.echo('{0}\t{1}\t{2}\t{3}'.format(test_.id, test_.name, last_run_date, test_.config))
+    except ConnectionError:
+        click.echo("Cannot connect to Load impact API")

--- a/loadimpactcli/test_commands.py
+++ b/loadimpactcli/test_commands.py
@@ -52,3 +52,14 @@ def list_tests(project_ids):
             click.echo('{0}\t{1}\t{2}\t{3}'.format(test_.id, test_.name, last_run_date, test_.config))
     except ConnectionError:
         click.echo("Cannot connect to Load impact API")
+
+
+@test.command('run', short_help='Run a test.')
+@click.argument('test_id')
+def list_tests(test_id):
+    try:
+        test_ = client.get_test(test_id)
+        test_run = test_.start_test_run()
+        click.echo('{0}'.format(test_run.id))
+    except ConnectionError:
+        click.echo("Cannot connect to Load impact API")

--- a/loadimpactcli/userscenario_commands.py
+++ b/loadimpactcli/userscenario_commands.py
@@ -83,9 +83,9 @@ def create_scenario(script_file, name, project_id, datastore_file, datastore_id)
             }
             try:
                 data_store = client.create_data_store(data_store_json, data_store_file)
+                data_store_ids.append(data_store.id)
             except ConnectionError:
                 click.echo("Cannot connect to Load impact API")
-            data_store_ids.append(data_store.id)
 
     data_store_ids += datastore_id
 

--- a/loadimpactcli/util.py
+++ b/loadimpactcli/util.py
@@ -15,8 +15,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from enum import Enum
+import sys
+
 from click import unstyle
+from enum import Enum
 
 
 class Style(Enum):
@@ -221,5 +223,11 @@ class ColumnFormatter(object):
                 val_ = val_[:width_ - 3] + '...'
 
             return u'{:{width}}'.format(val_, width=width_)
-        return self.separator.join([format_cell(str(val), width)
+
+        if sys.version_info >= (3, 0):
+            decode = str
+        else:
+            decode = unicode
+
+        return self.separator.join([format_cell(decode(val), width)
                                     for width, val in zip(self.widths, args)]).rstrip()

--- a/loadimpactcli/util.py
+++ b/loadimpactcli/util.py
@@ -218,7 +218,7 @@ class ColumnFormatter(object):
                 return val_
 
             if len(val_) > width_:
-                val_ = val_[:width_-3] + '...'
+                val_ = val_[:width_ - 3] + '...'
 
             return u'{:{width}}'.format(val_, width=width_)
         return self.separator.join([format_cell(unicode(val), width)

--- a/loadimpactcli/util.py
+++ b/loadimpactcli/util.py
@@ -1,0 +1,65 @@
+# coding=utf-8
+"""
+Copyright 2017 Load Impact
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from enum import Enum
+
+
+class Style(Enum):
+    """
+    Foreground colors used in the UI.
+    """
+    NONE = None
+    SUCCESS = 'green'
+    WARNING = 'yellow'
+    ERROR = 'red'
+
+
+class TestRunStatus(Enum):
+    """
+    Representation of a TestRun status.
+    """
+    STATUS_CREATED = -1
+    STATUS_QUEUED = 0
+    STATUS_INITIALIZING = 1
+    STATUS_RUNNING = 2
+    STATUS_FINISHED = 3
+    STATUS_TIMED_OUT = 4
+    STATUS_ABORTING_USER = 5
+    STATUS_ABORTED_USER = 6
+    STATUS_ABORTING_SYSTEM = 7
+    STATUS_ABORTED_SYSTEM = 8
+    STATUS_ABORTED_SCRIPT_ERROR = 9
+    STATUS_ABORTING_THRESHOLD = 10
+    STATUS_ABORTED_THRESHOLD = 11
+    STATUS_FAILED_THRESHOLD = 12
+
+    @property
+    def style(self):
+        if self in (TestRunStatus.STATUS_CREATED, TestRunStatus.STATUS_QUEUED,
+                    TestRunStatus.STATUS_INITIALIZING, TestRunStatus.STATUS_RUNNING):
+            return Style.WARNING
+        elif self in (TestRunStatus.STATUS_TIMED_OUT, TestRunStatus.STATUS_ABORTING_USER,
+                      TestRunStatus.STATUS_ABORTED_USER, TestRunStatus.STATUS_ABORTING_SYSTEM,
+                      TestRunStatus.STATUS_ABORTED_SYSTEM, TestRunStatus.STATUS_ABORTED_SCRIPT_ERROR,
+                      TestRunStatus.STATUS_ABORTING_THRESHOLD, TestRunStatus.STATUS_ABORTED_THRESHOLD,
+                      TestRunStatus.STATUS_FAILED_THRESHOLD):
+            return Style.ERROR
+        elif self == TestRunStatus.STATUS_FINISHED:
+            return Style.SUCCESS
+
+        return Style.NONE
+

--- a/loadimpactcli/util.py
+++ b/loadimpactcli/util.py
@@ -221,5 +221,5 @@ class ColumnFormatter(object):
                 val_ = val_[:width_ - 3] + '...'
 
             return u'{:{width}}'.format(val_, width=width_)
-        return self.separator.join([format_cell(unicode(val), width)
+        return self.separator.join([format_cell(str(val), width)
                                     for width, val in zip(self.widths, args)]).rstrip()

--- a/loadimpactcli/util.py
+++ b/loadimpactcli/util.py
@@ -63,3 +63,94 @@ class TestRunStatus(Enum):
 
         return Style.NONE
 
+
+class DefaultMetricType(Enum):
+    """
+    Representation of a Metric.
+    """
+    ACCUMULATED_LOAD_TIME = 'acc load time'
+    BANDWIDTH = 'bandwidth'
+    CLIENTS_ACTIVE = 'VUs'
+    CONNECTIONS_ACTIVE = 'connections'
+    CONTENT_TYPE = 'content type'
+    CONTENT_TYPE_LOAD_TIME = 'content type load time'
+    FAILURE_RATE = 'failure rate'
+    LIVE_FEEDBACK = 'feedback'
+    LOADGEN_CPU_UTILIZATION = 'cpu'
+    LOADGEN_MEMORY_UTILIZATION = 'mem'
+    LOG = 'log'
+    PROGRESS_PERCENT_TOTAL = 'progress'
+    REPS_FAILED_PERCENT = 'failed'
+    REPS_SUCCEEDED_PERCENT = 'successful'
+    REQUESTS_PER_SECOND = 'reqs/s'
+    TOTAL_RX_BYTES = 'rx'
+    TOTAL_REQUESTS = 'reqs'
+    USER_LOAD_TIME = 'user load time'
+
+    @classmethod
+    def from_raw(cls, str_raw):
+        return cls.__members__[str_raw.replace('__li_', '', 1).upper()]
+
+    def str_param(self):
+        return self.name.lower()
+
+    def str_raw(self):
+        return u'__li_{0}'.format(self.name.lower())
+
+    def str_ui(self):
+        return self.value
+
+
+class OtherMetricType(object):
+    def __init__(self, metric_id):
+        self.metric_id = metric_id
+
+    def str_param(self):
+        return '-'
+
+    def str_raw(self):
+        return self.metric_id
+
+    def str_ui(self):
+        if self.metric_id.startswith('__li_url') or self.metric_id.startswith('__li_page'):
+            return self.metric_id.replace('__li_', '').split('_')[0]
+        elif self.metric_id.startswith('__server_metric'):
+            return 'server metric'
+        elif self.metric_id.startswith('__custom_'):
+            return 'custom'
+
+        return self.metric_id
+
+
+class Metric(object):
+    def __init__(self, metric_type, params):
+        self.metric_type = metric_type
+        self.params = params
+
+    @classmethod
+    def from_raw(cls, str_raw):
+        # Split the string into metric id and parameters.
+        str_raw = str_raw.split('|')[0]
+        str_parts = str_raw.split(':')
+        str_raw, params = str_parts[0], str_parts[1:] or ['1']
+
+        try:
+            metric_type = DefaultMetricType.from_raw(str_raw)
+        except KeyError:
+            metric_type = OtherMetricType(str_raw)
+        return cls(metric_type, params)
+
+    def str_param(self):
+        return self.metric_type.str_param()
+
+    def str_raw(self, with_params=False):
+        if with_params:
+            return u':'.join([self.metric_type.str_raw()] + self.params)
+        else:
+            return self.metric_type.str_raw()
+
+    def str_ui(self, with_params=False):
+        if with_params and self.params:
+            return u'{0} [{1}]'.format(self.metric_type.str_ui(), u' '.join(self.params))
+        else:
+            return self.metric_type.str_ui()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ loadimpact-v3==0.0.3
 click==6.2
 tzlocal==1.2.2
 six==1.10.0
+enum34==1.1.6

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ setup(
         'loadimpact-v3',
         'tzlocal',
         'six',
-        'mock'
+        'mock',
+        'enum34'
     ],
     test_requires=['coverage'],
     entry_points={

--- a/tests/test_metric_commands.py
+++ b/tests/test_metric_commands.py
@@ -21,7 +21,6 @@ os.environ['LOADIMPACT_API_V3_TOKEN'] = 'token'
 
 import unittest
 from collections import namedtuple
-from datetime import datetime
 
 from click.testing import CliRunner
 from loadimpactcli import metric_commands
@@ -60,9 +59,9 @@ class TestMetric(unittest.TestCase):
         self.assertEqual(client.list_test_run_result_ids.call_count, 1)
         output = result.output.split('\n')
         self.assertEqual(len(output), 2+3)
-        self.assertEqual(output[1], 'result_id_1_1\ttext_for_type_1')
-        self.assertEqual(output[2], 'result_id_1_2\ttext_for_type_1')
-        self.assertEqual(output[3], 'result_id_2_1\ttext_for_type_2')
+        self.assertEqual(output[1], 'result_id_1_1\t-\ttext_for_type_1')
+        self.assertEqual(output[2], 'result_id_1_2\t-\ttext_for_type_1')
+        self.assertEqual(output[3], 'result_id_2_1\t-\ttext_for_type_2')
 
     def test_list_metric_with_types(self):
         """
@@ -78,9 +77,9 @@ class TestMetric(unittest.TestCase):
         self.assertEqual(client.list_test_run_result_ids.call_count, 1)
         output = result.output.split('\n')
         self.assertEqual(len(output), 2+3)
-        self.assertEqual(output[1], 'result_id_1_1\ttext_for_type_1')
-        self.assertEqual(output[2], 'result_id_1_2\ttext_for_type_1')
-        self.assertEqual(output[3], 'result_id_2_1\ttext_for_type_2')
+        self.assertEqual(output[1], 'result_id_1_1\t-\ttext_for_type_1')
+        self.assertEqual(output[2], 'result_id_1_2\t-\ttext_for_type_1')
+        self.assertEqual(output[3], 'result_id_2_1\t-\ttext_for_type_2')
 
     def test_list_metric_invalid_type(self):
         """

--- a/tests/test_metric_commands.py
+++ b/tests/test_metric_commands.py
@@ -1,0 +1,97 @@
+# coding=utf-8
+"""
+Copyright 2017 Load Impact
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+# Without this the config will prompt for a token
+import os
+os.environ['LOADIMPACT_API_V3_TOKEN'] = 'token'
+
+import unittest
+from collections import namedtuple
+from datetime import datetime
+
+from click.testing import CliRunner
+from loadimpactcli import metric_commands
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
+
+TestRunResultId = namedtuple('TestRunResultId', ['type', 'ids', 'results_type_code_to_text'])
+
+
+class TestMetric(unittest.TestCase):
+
+    def setUp(self):
+        self.runner = CliRunner()
+        self.result_ids = [TestRunResultId(1, {'result_id_1_1': '', 'result_id_1_2': ''},
+                                           self._results_type_code_to_text),
+                           TestRunResultId(2, {'result_id_2_1': ''}, self._results_type_code_to_text)]
+
+    def _results_type_code_to_text(self, type_):
+        return 'text_for_type_{}'.format(type_)
+
+    def test_list_metric_no_type(self):
+        """
+        Test "test metric" without specifying metric type.
+        """
+        client = metric_commands.client
+
+        # Setup mockers.
+        client.list_test_run_result_ids = MagicMock(return_value=self.result_ids)
+
+        result = self.runner.invoke(metric_commands.list_metrics, ['1'])
+
+        self.assertEqual(client.list_test_run_result_ids.call_count, 1)
+        output = result.output.split('\n')
+        self.assertEqual(len(output), 2+3)
+        self.assertEqual(output[1], 'result_id_1_1\ttext_for_type_1')
+        self.assertEqual(output[2], 'result_id_1_2\ttext_for_type_1')
+        self.assertEqual(output[3], 'result_id_2_1\ttext_for_type_2')
+
+    def test_list_metric_with_types(self):
+        """
+        Test "test metric" specifying metric type.
+        """
+        client = metric_commands.client
+
+        # Setup mockers.
+        client.list_test_run_result_ids = MagicMock(return_value=self.result_ids)
+
+        result = self.runner.invoke(metric_commands.list_metrics, ['1', '--type', 'common', '--type', 'url'])
+
+        self.assertEqual(client.list_test_run_result_ids.call_count, 1)
+        output = result.output.split('\n')
+        self.assertEqual(len(output), 2+3)
+        self.assertEqual(output[1], 'result_id_1_1\ttext_for_type_1')
+        self.assertEqual(output[2], 'result_id_1_2\ttext_for_type_1')
+        self.assertEqual(output[3], 'result_id_2_1\ttext_for_type_2')
+
+    def test_list_metric_invalid_type(self):
+        """
+        Test "test metric" specifying an invalid metric type.
+        """
+        client = metric_commands.client
+
+        # Setup mockers.
+        client.list_test_run_result_ids = MagicMock(return_value=self.result_ids)
+
+        result = self.runner.invoke(metric_commands.list_metrics, ['1', '--type', 'INVALID'])
+
+        self.assertEqual(client.list_test_run_result_ids.call_count, 0)
+        self.assertEqual(result.exit_code, 2)

--- a/tests/test_metric_commands.py
+++ b/tests/test_metric_commands.py
@@ -24,6 +24,7 @@ from collections import namedtuple
 
 from click.testing import CliRunner
 from loadimpactcli import metric_commands
+from loadimpactcli.util import Metric
 
 try:
     from unittest.mock import MagicMock
@@ -32,6 +33,7 @@ except ImportError:
 
 
 TestRunResultId = namedtuple('TestRunResultId', ['type', 'ids', 'results_type_code_to_text'])
+MetricRepresentation = namedtuple('MetricRepresentation', ['full', 'raw', 'as_param', 'args'])
 
 
 class TestMetric(unittest.TestCase):
@@ -41,6 +43,13 @@ class TestMetric(unittest.TestCase):
         self.result_ids = [TestRunResultId(1, {'result_id_1_1': '', 'result_id_1_2': ''},
                                            self._results_type_code_to_text),
                            TestRunResultId(2, {'result_id_2_1': ''}, self._results_type_code_to_text)]
+
+    def _assertExpectedMetric(self, metric_representation, metric, include_full=True):
+        if include_full:
+            self.assertEqual(metric_representation.full, metric.str_raw(True))
+        self.assertEqual(metric_representation.raw, metric.str_raw(False))
+        self.assertEqual(metric_representation.as_param, metric.str_param())
+        self.assertEqual(metric_representation.args, metric.params)
 
     def _results_type_code_to_text(self, type_):
         return 'text_for_type_{}'.format(type_)
@@ -94,3 +103,73 @@ class TestMetric(unittest.TestCase):
 
         self.assertEqual(client.list_test_run_result_ids.call_count, 0)
         self.assertEqual(result.exit_code, 2)
+
+    def test_standard_metric(self):
+        """
+        Test representation of standard metrics.
+        """
+        # Metric with parameters from full raw string.
+        expected_metric_1 = MetricRepresentation('__li_bandwidth:1', '__li_bandwidth', 'bandwidth', ['1'])
+        metric_1 = Metric.from_raw(expected_metric_1.full)
+        self._assertExpectedMetric(expected_metric_1, metric_1)
+
+        # Metric with parameters from full raw string and slicing: slicing is dropped.
+        expected_metric_2 = MetricRepresentation('__li_bandwidth:1|1:2', '__li_bandwidth', 'bandwidth', ['1'])
+        metric_2 = Metric.from_raw(expected_metric_2.full)
+        self._assertExpectedMetric(expected_metric_2, metric_2, False)
+        self.assertEqual(expected_metric_2.full.split('|')[0], metric_2.str_raw(True))
+
+        # Metric with no parameters: load zone 1 is appended.
+        expected_metric_3 = MetricRepresentation('__li_bandwidth', '__li_bandwidth', 'bandwidth', ['1'])
+        metric_3 = Metric.from_raw(expected_metric_3.full)
+        self._assertExpectedMetric(expected_metric_3, metric_3, False)
+        self.assertEqual('{0}:1'.format(expected_metric_3.full), metric_3.str_raw(True))
+
+        # Construct the metrics from the parameter representation.
+        metric_1_param = Metric.from_raw(expected_metric_1.as_param)
+        metric_2_param = Metric.from_raw(expected_metric_1.as_param)
+        metric_3_param = Metric.from_raw(expected_metric_1.as_param)
+        self.assertEqual(metric_1, metric_1_param)
+        self.assertEqual(metric_2, metric_2_param)
+        self.assertEqual(metric_3, metric_3_param)
+
+        # Check equivalence of the metrics.
+        self.assertEqual(metric_1, metric_2)
+        self.assertEqual(metric_2, metric_3)
+
+        # Metric with different parameters from full raw string.
+        expected_metric_4 = MetricRepresentation('__li_bandwidth:1:2:x', '__li_bandwidth', 'bandwidth',
+                                                 ['1', '2', 'x'])
+        metric_4 = Metric.from_raw(expected_metric_4.full)
+        self._assertExpectedMetric(expected_metric_4, metric_4)
+        self.assertNotEqual(metric_1, metric_4)
+
+    def test_non_standard_metric(self):
+        """
+        Test representation of non standard metrics.
+        """
+        # Metric with parameters from full raw string.
+        expected_metric_1 = MetricRepresentation('__li_foo:1', '__li_foo', '-', ['1'])
+        metric_1 = Metric.from_raw(expected_metric_1.full)
+        self._assertExpectedMetric(expected_metric_1, metric_1)
+
+        # Metric with parameters from full raw string and slicing: slicing is dropped.
+        expected_metric_2 = MetricRepresentation('__li_foo:1|1:2', '__li_foo', '-', ['1'])
+        metric_2 = Metric.from_raw(expected_metric_2.full)
+        self._assertExpectedMetric(expected_metric_2, metric_2, False)
+        self.assertEqual(expected_metric_2.full.split('|')[0], metric_2.str_raw(True))
+
+        # Metric with no parameters: load zone 1 is appended.
+        expected_metric_3 = MetricRepresentation('__li_foo', '__li_foo', '-', [])
+        metric_3 = Metric.from_raw(expected_metric_3.full)
+        self._assertExpectedMetric(expected_metric_3, metric_3)
+
+        # Check equivalence of the metrics.
+        self.assertEqual(metric_1, metric_2)
+        # Metrics 2 and 3 are not equal due to having different parameters.
+        self.assertNotEqual(metric_2, metric_3)
+
+        # Metric without __li_ prefix and unicode characters.
+        expected_metric_4 = MetricRepresentation(u'foöbår:0:ßåŕ', u'foöbår', '-', ['0', u'ßåŕ'])
+        metric_4 = Metric.from_raw(expected_metric_4.full)
+        self._assertExpectedMetric(expected_metric_4, metric_4)

--- a/tests/test_metric_commands.py
+++ b/tests/test_metric_commands.py
@@ -67,7 +67,7 @@ class TestMetric(unittest.TestCase):
 
         self.assertEqual(client.list_test_run_result_ids.call_count, 1)
         output = result.output.split('\n')
-        self.assertEqual(len(output), 2+3)
+        self.assertEqual(len(output), 2 + 3)
         self.assertEqual(output[1], 'result_id_1_1\t-\ttext_for_type_1')
         self.assertEqual(output[2], 'result_id_1_2\t-\ttext_for_type_1')
         self.assertEqual(output[3], 'result_id_2_1\t-\ttext_for_type_2')
@@ -85,7 +85,7 @@ class TestMetric(unittest.TestCase):
 
         self.assertEqual(client.list_test_run_result_ids.call_count, 1)
         output = result.output.split('\n')
-        self.assertEqual(len(output), 2+3)
+        self.assertEqual(len(output), 2 + 3)
         self.assertEqual(output[1], 'result_id_1_1\t-\ttext_for_type_1')
         self.assertEqual(output[2], 'result_id_1_2\t-\ttext_for_type_1')
         self.assertEqual(output[3], 'result_id_2_1\t-\ttext_for_type_2')

--- a/tests/test_test_commands.py
+++ b/tests/test_test_commands.py
@@ -57,7 +57,7 @@ class TestTestsList(unittest.TestCase):
         # Setup mockers.
         client.list_tests = MagicMock(return_value=self.tests)
         client.get_test_run = MagicMock(return_value=TestRun(1, datetime.now(), 0, 'status'))
-        result = self.runner.invoke(test_commands.list_tests, ['--project_id', '1'])
+        result = self.runner.invoke(test_commands.list_tests, ['--project_id', '1', '--full_width'])
 
         self.assertEqual(client.list_tests.call_count, 1)
         self.assertEqual(client.get_test_run.call_count, 3)

--- a/tests/test_test_commands.py
+++ b/tests/test_test_commands.py
@@ -33,7 +33,7 @@ except ImportError:
 
 
 Test = namedtuple('Test', ['id', 'name', 'last_test_run_id', 'config'])
-TestRun = namedtuple('TestRun', ['id', 'queued'])
+TestRun = namedtuple('TestRun', ['id', 'queued', 'status_text'])
 Organization = namedtuple('Organization', ['id'])
 Project = namedtuple('Project', ['id'])
 
@@ -54,7 +54,7 @@ class TestTest(unittest.TestCase):
 
         # Setup mockers.
         client.list_tests = MagicMock(return_value=self.tests)
-        client.get_test_run = MagicMock(return_value=TestRun(1, datetime.now()))
+        client.get_test_run = MagicMock(return_value=TestRun(1, datetime.now(), 'status'))
         result = self.runner.invoke(test_commands.list_tests, ['--project_id', '1'])
 
         self.assertEqual(client.list_tests.call_count, 1)
@@ -73,7 +73,7 @@ class TestTest(unittest.TestCase):
 
         # Setup mockers.
         client.list_tests = MagicMock(return_value=self.tests)
-        client.get_test_run = MagicMock(return_value=TestRun(1, datetime.now()))
+        client.get_test_run = MagicMock(return_value=TestRun(1, datetime.now(), 'status'))
         result = self.runner.invoke(test_commands.list_tests, ['--project_id', '1',
                                                                '--project_id', '2'])
 
@@ -92,7 +92,7 @@ class TestTest(unittest.TestCase):
 
         # Setup mockers.
         client.list_tests = MagicMock(return_value=self.tests)
-        client.get_test_run = MagicMock(return_value=TestRun(1, datetime.now()))
+        client.get_test_run = MagicMock(return_value=TestRun(1, datetime.now(), 'status'))
         client.list_organizations = MagicMock(return_value=[Organization(1), Organization(2)])
         client.list_organization_projects = MagicMock(side_effect=[[Project(1), Project(2)],
                                                                    [Project(3), Project(4)]])

--- a/tests/test_test_commands.py
+++ b/tests/test_test_commands.py
@@ -268,8 +268,7 @@ class TestTestsRun(unittest.TestCase):
 
         # Assertions on the output.
         output = result.output.split('\n')
-        self.assertEqual(len(output), 5)
         # Results table assertions (one row, one metric).
-        self.assertEqual(len(output), 5)
+        self.assertEqual(len(output), 6)
         self.assertEqual(len(output[-2].split('\t')), 6)
         self.assertEqual(output[-2].split('\t')[1], '1.23')

--- a/tests/test_test_commands.py
+++ b/tests/test_test_commands.py
@@ -62,7 +62,7 @@ class TestTestsList(unittest.TestCase):
         self.assertEqual(client.list_tests.call_count, 1)
         self.assertEqual(client.get_test_run.call_count, 3)
         output = result.output.split('\n')
-        self.assertEqual(len(output), 2+3)
+        self.assertEqual(len(output), 2 + 3)
         self.assertTrue(output[1].startswith('1\tTest1\t'))
         self.assertTrue(output[2].startswith('2\tTest2\t'))
         self.assertTrue(output[3].startswith('3\tTest3\t'))
@@ -82,7 +82,7 @@ class TestTestsList(unittest.TestCase):
         self.assertEqual(client.list_tests.call_count, 2)
         self.assertEqual(client.get_test_run.call_count, 6)
         output = result.output.split('\n')
-        self.assertEqual(len(output), 2+2*3)
+        self.assertEqual(len(output), 2 + 2 * 3)
 
     def test_list_tests_no_project_id(self):
         """
@@ -102,10 +102,10 @@ class TestTestsList(unittest.TestCase):
 
         self.assertEqual(client.list_organizations.call_count, 1)
         self.assertEqual(client.list_organization_projects.call_count, 2)
-        self.assertEqual(client.list_tests.call_count, 2*2)
-        self.assertEqual(client.get_test_run.call_count, 2*2*3)
+        self.assertEqual(client.list_tests.call_count, 2 * 2)
+        self.assertEqual(client.get_test_run.call_count, 2 * 2 * 3)
         output = result.output.split('\n')
-        self.assertEqual(len(output), 2+2*2*3)
+        self.assertEqual(len(output), 2 + 2 * 2 * 3)
 
     def test_list_tests_limit_not_hit(self):
         """
@@ -123,7 +123,7 @@ class TestTestsList(unittest.TestCase):
         self.assertEqual(client.list_tests.call_count, 1)
         self.assertEqual(client.get_test_run.call_count, 3)
         output = result.output.split('\n')
-        self.assertEqual(len(output), 2+3)
+        self.assertEqual(len(output), 2 + 3)
 
         # Invokation with flag: limit is 1, 1 test listed, extra line.
         client.list_tests.reset_mock()
@@ -134,7 +134,7 @@ class TestTestsList(unittest.TestCase):
         self.assertEqual(client.list_tests.call_count, 1)
         self.assertEqual(client.get_test_run.call_count, 1)
         output = result.output.split('\n')
-        self.assertEqual(len(output), 2+1+1)
+        self.assertEqual(len(output), 2 + 1 + 1)
 
     def test_summarize_valid_config(self):
         config = {u'new_relic_applications': [],
@@ -143,13 +143,11 @@ class TestTestsList(unittest.TestCase):
                   u'server_metric_agents': [],
                   u'tracks': [
                       {u'clips': [{u'user_scenario_id': 225, u'percent': 100}],
-                       u'loadzone': u'amazon:ie:dublin'}
-                  ],
+                       u'loadzone': u'amazon:ie:dublin'}],
                   u'url_groups': [],
                   u'load_schedule': [
                       {u'duration': 1, u'users': 50},
-                      {u'duration': 2, u'users': 100}
-                  ],
+                      {u'duration': 2, u'users': 100}],
                   u'source_ips': 0}
         summary = test_commands.summarize_config(config)
         self.assertEqual(summary, '50 users 1s; 100 users 2s')

--- a/tests/test_test_commands.py
+++ b/tests/test_test_commands.py
@@ -1,0 +1,128 @@
+# coding=utf-8
+"""
+Copyright 2017 Load Impact
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+# Without this the config will prompt for a token
+import os
+os.environ['LOADIMPACT_API_V3_TOKEN'] = 'token'
+
+import unittest
+from collections import namedtuple
+from datetime import datetime
+
+from click.testing import CliRunner
+from loadimpactcli import test_commands
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
+
+Test = namedtuple('Test', ['id', 'name', 'last_test_run_id', 'config'])
+TestRun = namedtuple('TestRun', ['id', 'queued'])
+Organization = namedtuple('Organization', ['id'])
+Project = namedtuple('Project', ['id'])
+
+
+class TestTest(unittest.TestCase):
+
+    def setUp(self):
+        self.runner = CliRunner()
+        self.tests = [Test(1, 'Test1', 10001, ''),
+                      Test(2, 'Test2', 10002, ''),
+                      Test(3, 'Test3', 10003, '')]
+
+    def test_list_tests_one_project_id(self):
+        """
+        Test "test list" with 1 project id and 3 tests.
+        """
+        client = test_commands.client
+
+        # Setup mockers.
+        client.list_tests = MagicMock(return_value=self.tests)
+        client.get_test_run = MagicMock(return_value=TestRun(1, datetime.now()))
+        result = self.runner.invoke(test_commands.list_tests, ['--project_id', '1'])
+
+        self.assertEqual(client.list_tests.call_count, 1)
+        self.assertEqual(client.get_test_run.call_count, 3)
+        output = result.output.split('\n')
+        self.assertEqual(len(output), 2+3)
+        self.assertTrue(output[1].startswith('1\tTest1\t'))
+        self.assertTrue(output[2].startswith('2\tTest2\t'))
+        self.assertTrue(output[3].startswith('3\tTest3\t'))
+
+    def test_list_tests_several_project_id(self):
+        """
+        Test "test list" with 2 project id and 6 tests.
+        """
+        client = test_commands.client
+
+        # Setup mockers.
+        client.list_tests = MagicMock(return_value=self.tests)
+        client.get_test_run = MagicMock(return_value=TestRun(1, datetime.now()))
+        result = self.runner.invoke(test_commands.list_tests, ['--project_id', '1',
+                                                               '--project_id', '2'])
+
+        self.assertEqual(client.list_tests.call_count, 2)
+        self.assertEqual(client.get_test_run.call_count, 6)
+        output = result.output.split('\n')
+        self.assertEqual(len(output), 2+2*3)
+
+    def test_list_tests_no_project_id(self):
+        """
+        Test "test list" with no project id. The test simulates 2
+        organizations, with 2 projects per organization, with 3 tests per
+        project.
+        """
+        client = test_commands.client
+
+        # Setup mockers.
+        client.list_tests = MagicMock(return_value=self.tests)
+        client.get_test_run = MagicMock(return_value=TestRun(1, datetime.now()))
+        client.list_organizations = MagicMock(return_value=[Organization(1), Organization(2)])
+        client.list_organization_projects = MagicMock(side_effect=[[Project(1), Project(2)],
+                                                                   [Project(3), Project(4)]])
+        result = self.runner.invoke(test_commands.list_tests)
+
+        self.assertEqual(client.list_organizations.call_count, 1)
+        self.assertEqual(client.list_organization_projects.call_count, 2)
+        self.assertEqual(client.list_tests.call_count, 2*2)
+        self.assertEqual(client.get_test_run.call_count, 2*2*3)
+        output = result.output.split('\n')
+        self.assertEqual(len(output), 2+2*2*3)
+
+    def test_summarize_valid_config(self):
+        config = {u'new_relic_applications': [],
+                  u'network_emulation': {u'client': u'li', u'network': u'unlimited'},
+                  u'user_type': u'sbu',
+                  u'server_metric_agents': [],
+                  u'tracks': [
+                      {u'clips': [{u'user_scenario_id': 225, u'percent': 100}],
+                       u'loadzone': u'amazon:ie:dublin'}
+                  ],
+                  u'url_groups': [],
+                  u'load_schedule': [
+                      {u'duration': 1, u'users': 50}
+                  ],
+                  u'source_ips': 0}
+        summary = test_commands.summarize_config(config)
+        self.assertEqual(summary, '#225 100% at amazon:ie:dublin | 1s 50users')
+
+    def test_summarize_invalid_config(self):
+        config = 'INVALID'
+        summary = test_commands.summarize_config(config)
+        self.assertEqual(summary, config)

--- a/tests/test_test_commands.py
+++ b/tests/test_test_commands.py
@@ -38,7 +38,7 @@ Organization = namedtuple('Organization', ['id'])
 Project = namedtuple('Project', ['id'])
 
 
-class TestTest(unittest.TestCase):
+class TestTests(unittest.TestCase):
 
     def setUp(self):
         self.runner = CliRunner()

--- a/tests/test_test_commands.py
+++ b/tests/test_test_commands.py
@@ -33,7 +33,7 @@ except ImportError:
 
 
 Test = namedtuple('Test', ['id', 'name', 'last_test_run_id', 'config'])
-TestRun = namedtuple('TestRun', ['id', 'queued', 'status_text'])
+TestRun = namedtuple('TestRun', ['id', 'queued', 'status', 'status_text'])
 Organization = namedtuple('Organization', ['id'])
 Project = namedtuple('Project', ['id'])
 
@@ -54,7 +54,7 @@ class TestTest(unittest.TestCase):
 
         # Setup mockers.
         client.list_tests = MagicMock(return_value=self.tests)
-        client.get_test_run = MagicMock(return_value=TestRun(1, datetime.now(), 'status'))
+        client.get_test_run = MagicMock(return_value=TestRun(1, datetime.now(), 0, 'status'))
         result = self.runner.invoke(test_commands.list_tests, ['--project_id', '1'])
 
         self.assertEqual(client.list_tests.call_count, 1)
@@ -73,7 +73,7 @@ class TestTest(unittest.TestCase):
 
         # Setup mockers.
         client.list_tests = MagicMock(return_value=self.tests)
-        client.get_test_run = MagicMock(return_value=TestRun(1, datetime.now(), 'status'))
+        client.get_test_run = MagicMock(return_value=TestRun(1, datetime.now(), 0, 'status'))
         result = self.runner.invoke(test_commands.list_tests, ['--project_id', '1',
                                                                '--project_id', '2'])
 
@@ -92,7 +92,7 @@ class TestTest(unittest.TestCase):
 
         # Setup mockers.
         client.list_tests = MagicMock(return_value=self.tests)
-        client.get_test_run = MagicMock(return_value=TestRun(1, datetime.now(), 'status'))
+        client.get_test_run = MagicMock(return_value=TestRun(1, datetime.now(), 0, 'status'))
         client.list_organizations = MagicMock(return_value=[Organization(1), Organization(2)])
         client.list_organization_projects = MagicMock(side_effect=[[Project(1), Project(2)],
                                                                    [Project(3), Project(4)]])
@@ -116,13 +116,14 @@ class TestTest(unittest.TestCase):
                   ],
                   u'url_groups': [],
                   u'load_schedule': [
-                      {u'duration': 1, u'users': 50}
+                      {u'duration': 1, u'users': 50},
+                      {u'duration': 2, u'users': 100}
                   ],
                   u'source_ips': 0}
         summary = test_commands.summarize_config(config)
-        self.assertEqual(summary, '#225 100% at amazon:ie:dublin | 1s 50users')
+        self.assertEqual(summary, '50 users 1s; 100 users 2s')
 
     def test_summarize_invalid_config(self):
         config = 'INVALID'
         summary = test_commands.summarize_config(config)
-        self.assertEqual(summary, config)
+        self.assertEqual(summary, '-')


### PR DESCRIPTION
Additions to the `cli` for listing Tests, starting (with streaming) TestRuns, and listing Metrics, in tandem with the changes on the SDK at https://github.com/loadimpact/loadimpact-sdk-python/pull/7.
