### PR TITLE
[feat] delete action for data stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,21 @@ The ```data-store update``` command will update the file of the specified Data s
 $ loadimpact data-store update 1 /path/to/file.csv
 ```
 
+#### Deleting a Data store
+
+The ```data-store delete``` command will delete an existing Data store. Since this is a destructive action you'll need to verify it. 
+
+```
+$ loadimpact data-store delete 1
+
+```
+If you need to bypass the verifying you can add the ```--yes``` flag. 
+
+```
+$ loadimpact data-store delete 1 --yes
+
+```
+
 ## Working with Tests
 
 #### Listing Tests

--- a/loadimpactcli/datastore_commands.py
+++ b/loadimpactcli/datastore_commands.py
@@ -123,6 +123,16 @@ def update_datastore(id, datastore_file, name, project_id, delimiter, separator,
         click.echo("Cannot connect to Load impact API")
 
 
+@data_store.command('delete', short_help='Delete data-store.')
+@click.confirmation_option(help='Are you sure you want to delete the data-store?')
+@click.argument('datastore_id')
+def delete_datastore(datastore_id):
+    try:
+        click.echo(delete_datastore(datastore_id))
+    except ConnectionError:
+        click.echo("Cannot connect to Load impact API")
+
+
 def _wait_for_conversion(data_store):
     while not data_store.has_conversion_finished():
         sleep(3)
@@ -135,3 +145,8 @@ def _download_csv(user_scenario, file_path):
         with open(file_path, 'wb') as f:
             response.raw.decode_content = True
             shutil.copyfileobj(response.raw, f)
+
+
+def delete_datastore(datastore_id):
+    datastore = client.get_data_store(datastore_id)
+    return datastore.delete()

--- a/loadimpactcli/datastore_commands.py
+++ b/loadimpactcli/datastore_commands.py
@@ -128,7 +128,7 @@ def update_datastore(id, datastore_file, name, project_id, delimiter, separator,
 @click.argument('datastore_id')
 def delete_datastore(datastore_id):
     try:
-        click.echo(delete_datastore(datastore_id))
+        click.echo(delete_store(datastore_id))
     except ConnectionError:
         click.echo("Cannot connect to Load impact API")
 
@@ -147,6 +147,6 @@ def _download_csv(user_scenario, file_path):
             shutil.copyfileobj(response.raw, f)
 
 
-def delete_datastore(datastore_id):
+def delete_store(datastore_id):
     datastore = client.get_data_store(datastore_id)
     return datastore.delete()

--- a/tests/test_datastore_commands.py
+++ b/tests/test_datastore_commands.py
@@ -128,7 +128,7 @@ class TestDataStores(unittest.TestCase):
         assert result.exit_code == 2
 
     def test_delete_datastore(self):
-        datastore_commands.delete_datastore = MagicMock(return_value="Datastore1")
+        datastore_commands.delete_store = MagicMock(return_value="Datastore1")
         result = self.runner.invoke(datastore_commands.delete_datastore, ['1', '--yes'])
         assert result.exit_code == 0
         assert result.output == 'Datastore1\n'

--- a/tests/test_datastore_commands.py
+++ b/tests/test_datastore_commands.py
@@ -126,3 +126,13 @@ class TestDataStores(unittest.TestCase):
 
         result = self.runner.invoke(datastore_commands.update_datastore, ['1'])
         assert result.exit_code == 2
+
+    def test_delete_datastore(self):
+        datastore_commands.delete_datastore = MagicMock(return_value="Datastore1")
+        result = self.runner.invoke(datastore_commands.delete_datastore, ['1', '--yes'])
+        assert result.exit_code == 0
+        assert result.output == 'Datastore1\n'
+
+    def test_delete_datastore_no_params(self):
+        result = self.runner.invoke(datastore_commands.delete_datastore, [])
+        assert result.exit_code == 2


### PR DESCRIPTION
Add the feature to delete data stores with the CLI tool. Currently deleting data stores is only possible with the API v2.